### PR TITLE
Creating valid kdbx files from scratch + more godocs comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,5 @@ _testmain.go
 *.exe
 
 #ignore kdbx file created by test
-tmp.kdbx
+examples/tmp.kdbx
+examples/new.kdbx

--- a/binary.go
+++ b/binary.go
@@ -9,10 +9,10 @@ import (
 	"io"
 )
 
-//Stores a slice of binaries in the metadata header
+//Binaries Stores a slice of binaries in the metadata header of a database
 type Binaries []Binary
 
-//Stores a binary found in the metadata header
+//Binary stores a binary found in the metadata header of a database
 type Binary struct {
 	Content    []byte     `xml:",innerxml"`
 	ID         int         `xml:"ID,attr"`
@@ -23,7 +23,7 @@ func (b Binary) String () (string) {
 	return fmt.Sprintf("ID: %d, Compressed:%t, Content:%x",b.ID,b.Compressed,b.Content)
 }
 
-//Stores a reference to binaries in entries
+//BinaryReference stores a reference to a binary which appears in the xml of an entry
 type BinaryReference struct {
 	Name	 string	   `xml:"Key"`
 	Value struct { 
@@ -35,12 +35,12 @@ func (br BinaryReference) String () (string) {
 	return fmt.Sprintf("ID: %d, File Name: %s",br.Value.ID,br.Name)
 }
 
-//Given a list of binaries bs, returns a reference to a binary with the same id as the reference, or nil
+//Find returns a reference to  a binary in the slice of binaries bs with the same id as br, or nil if none is found
 func (br *BinaryReference) Find (bs Binaries) (*Binary) {
 	return bs.Find(br.Value.ID)
 }
 
-//Returns a reference to a binary with id in binaries, or nil if none found
+//Find returns a reference to a binary with the same ID as id, or nil if none if found
 func (bs Binaries) Find (id int) (*Binary) {
 	for i,_ := range bs {
 		if bs[i].ID == id {
@@ -50,7 +50,7 @@ func (bs Binaries) Find (id int) (*Binary) {
 	return nil
 }
 
-//Returns a reader to read from the binary content, decompressing if nessesary
+//GetContent returns a string which is the plaintext content of a binary, may return an error if something goes wrong in decoding from base64 or decompressing
 func (b Binary) GetContent () (string,error) {
 	decoded := make([]byte,base64.StdEncoding.DecodedLen(len(b.Content)))
 	_,err := base64.StdEncoding.Decode(decoded,b.Content)

--- a/content.go
+++ b/content.go
@@ -53,7 +53,7 @@ type MetaData struct {
 func NewMetaData () (*MetaData) {
 	meta := new(MetaData)
 	now := time.Now()
-	*meta.MasterKeyChanged = now
+	meta.MasterKeyChanged = &now
 	meta.MasterKeyChangeRec = -1
 	meta.MasterKeyChangeForce = -1
 	return meta

--- a/content.go
+++ b/content.go
@@ -12,33 +12,51 @@ type DBContent struct {
 	Root    *RootData `xml:"Root"`
 }
 
+//Creates a new DB content with some good defaults
+func NewDBContent () (*DBContent) {
+	content := new(DBContent)
+	content.Meta = NewMetaData()
+	content.Root = NewRootData()
+	return content
+}
+
 //The metadata headers at the top of kdbx files, contains things like the name of the database
 type MetaData struct {
 	Generator                  string        `xml:"Generator"`
 	HeaderHash                 string        `xml:"HeaderHash"`
 	DatabaseName               string        `xml:"DatabaseName"`
-	DatabaseNameChanged        *time.Time    `xml:"DatabaseNameChanged"`
+	DatabaseNameChanged        time.Time    `xml:"DatabaseNameChanged"`
 	DatabaseDescription        string        `xml:"DatabaseDescription"`
-	DatabaseDescriptionChanged *time.Time    `xml:"DatabaseDescriptionChanged"`
+	DatabaseDescriptionChanged time.Time    `xml:"DatabaseDescriptionChanged"`
 	DefaultUserName            string        `xml:"DefaultUserName"`
-	DefaultUserNameChanged     *time.Time    `xml:"DefaultUserNameChanged"`
+	DefaultUserNameChanged     time.Time    `xml:"DefaultUserNameChanged"`
 	MaintenanceHistoryDays     string        `xml:"MaintenanceHistoryDays"`
 	Color                      string        `xml:"Color"`
-	MasterKeyChanged           *time.Time    `xml:"MasterKeyChanged"`
+	MasterKeyChanged           time.Time    `xml:"MasterKeyChanged"`
 	MasterKeyChangeRec         int64         `xml:"MasterKeyChangeRec"`
 	MasterKeyChangeForce       int64         `xml:"MasterKeyChangeForce"`
 	MemoryProtection           MemProtection `xml:"MemoryProtection"`
 	RecycleBinEnabled          boolWrapper   `xml:"RecycleBinEnabled"`
 	RecycleBinUUID             string        `xml:"RecycleBinUUID"`
-	RecycleBinChanged          *time.Time    `xml:"RecycleBinChanged"`
+	RecycleBinChanged          time.Time    `xml:"RecycleBinChanged"`
 	EntryTemplatesGroup        string        `xml:"EntryTemplatesGroup"`
-	EntryTemplatesGroupChanged *time.Time    `xml:"EntryTemplatesGroupChanged"`
+	EntryTemplatesGroupChanged time.Time    `xml:"EntryTemplatesGroupChanged"`
 	HistoryMaxItems            int64         `xml:"HistoryMaxItems"`
 	HistoryMaxSize             int64         `xml:"HistoryMaxSize"`
 	LastSelectedGroup          string        `xml:"LastSelectedGroup"`
 	LastTopVisibleGroup        string        `xml:"LastTopVisibleGroup"`
 	Binaries                   Binaries      `xml:"Binaries>Binary"`
 	CustomData                 string        `xml:"CustomData"`
+}
+
+//NewMetaData creates a MetaData struct with some defaults set
+func NewMetaData () (*MetaData) {
+	meta := new(MetaData)
+	now := time.Now()
+	meta.MasterKeyChanged = now
+	meta.MasterKeyChangeRec = -1
+	meta.MasterKeyChangeForce = -1
+	return meta
 }
 
 type MemProtection struct {
@@ -53,6 +71,12 @@ type MemProtection struct {
 type RootData struct {
 	Groups         []Group             `xml:"Group"`
 	DeletedObjects []DeletedObjectData `xml:"DeletedObjects>DeletedObject"`
+}
+
+//NewRootData returns a RootData struct with good defaults
+func NewRootData () (*RootData) {
+	root := new(RootData)
+	return root
 }
 
 //Structure to store entries in their named groups for organization
@@ -73,14 +97,28 @@ type Group struct {
 
 //All metadata relating to times for groups and entries, such as last modification time
 type TimeData struct {
-	CreationTime         *time.Time  `xml:"CreationTime"`
-	LastModificationTime *time.Time  `xml:"LastModificationTime"`
-	LastAcessTime        *time.Time  `xml:"LastAcessTime"`
-	ExpiryTime           *time.Time  `xml:"ExpiryTime"`
+	CreationTime         time.Time  `xml:"CreationTime"`
+	LastModificationTime time.Time  `xml:"LastModificationTime"`
+	LastAcessTime        time.Time  `xml:"LastAcessTime"`
+	ExpiryTime           time.Time  `xml:"ExpiryTime"`
 	Expires              boolWrapper `xml:"Expires"`
 	UsageCount           int64       `xml:"UsageCount"`
-	LocationChanged      *time.Time  `xml:"LocationChanged"`
+	LocationChanged      time.Time  `xml:"LocationChanged"`
 }
+
+//NewTimeData returns a TimeData struct with good defaults (no expire time, all times set to now)
+func NewTimeData () (TimeData) {
+	data := TimeData{}
+	now := time.Now()
+	data.CreationTime = now
+	data.LastModificationTime = now
+	data.LastAcessTime = now
+	data.Expires = false
+	data.UsageCount = 0
+	data.LocationChanged = now
+	return data
+}
+
 //structure for each parsed entry in a keepass database
 type Entry struct {
 	UUID            string            `xml:"UUID"`
@@ -172,5 +210,5 @@ type AutoTypeAssociation struct {
 type DeletedObjectData struct {
 	XMLName      xml.Name   `xml:"DeletedObject"`
 	UUID         string     `xml:"UUID"`
-	DeletionTime *time.Time `xml:"DeletionTime"`
+	DeletionTime time.Time `xml:"DeletionTime"`
 }

--- a/content.go
+++ b/content.go
@@ -110,12 +110,16 @@ type TimeData struct {
 func NewTimeData () (TimeData) {
 	data := TimeData{}
 	now := time.Now()
+	data.CreationTime = new(time.Time)
 	*data.CreationTime = now
+	data.LastModificationTime = new(time.Time)
 	*data.LastModificationTime = now
+	data.LastAcessTime = new(time.Time)
 	*data.LastAcessTime = now
+	data.LocationChanged = new(time.Time)
+	*data.LocationChanged = now
 	data.Expires = false
 	data.UsageCount = 0
-	*data.LocationChanged = now
 	return data
 }
 

--- a/content.go
+++ b/content.go
@@ -99,7 +99,7 @@ type Group struct {
 type TimeData struct {
 	CreationTime         *time.Time  `xml:"CreationTime"`
 	LastModificationTime *time.Time  `xml:"LastModificationTime"`
-	LastAcessTime        *time.Time  `xml:"LastAcessTime"`
+	LastAccessTime        *time.Time  `xml:"LastAccessTime"`
 	ExpiryTime           *time.Time  `xml:"ExpiryTime"`
 	Expires              boolWrapper `xml:"Expires"`
 	UsageCount           int64       `xml:"UsageCount"`
@@ -114,8 +114,8 @@ func NewTimeData () (TimeData) {
 	*data.CreationTime = now
 	data.LastModificationTime = new(time.Time)
 	*data.LastModificationTime = now
-	data.LastAcessTime = new(time.Time)
-	*data.LastAcessTime = now
+	data.LastAccessTime = new(time.Time)
+	*data.LastAccessTime = now
 	data.LocationChanged = new(time.Time)
 	*data.LocationChanged = now
 	data.Expires = false

--- a/content.go
+++ b/content.go
@@ -25,22 +25,22 @@ type MetaData struct {
 	Generator                  string        `xml:"Generator"`
 	HeaderHash                 string        `xml:"HeaderHash"`
 	DatabaseName               string        `xml:"DatabaseName"`
-	DatabaseNameChanged        time.Time    `xml:"DatabaseNameChanged"`
+	DatabaseNameChanged        *time.Time    `xml:"DatabaseNameChanged"`
 	DatabaseDescription        string        `xml:"DatabaseDescription"`
-	DatabaseDescriptionChanged time.Time    `xml:"DatabaseDescriptionChanged"`
+	DatabaseDescriptionChanged *time.Time    `xml:"DatabaseDescriptionChanged"`
 	DefaultUserName            string        `xml:"DefaultUserName"`
-	DefaultUserNameChanged     time.Time    `xml:"DefaultUserNameChanged"`
+	DefaultUserNameChanged     *time.Time    `xml:"DefaultUserNameChanged"`
 	MaintenanceHistoryDays     string        `xml:"MaintenanceHistoryDays"`
 	Color                      string        `xml:"Color"`
-	MasterKeyChanged           time.Time    `xml:"MasterKeyChanged"`
+	MasterKeyChanged           *time.Time    `xml:"MasterKeyChanged"`
 	MasterKeyChangeRec         int64         `xml:"MasterKeyChangeRec"`
 	MasterKeyChangeForce       int64         `xml:"MasterKeyChangeForce"`
 	MemoryProtection           MemProtection `xml:"MemoryProtection"`
 	RecycleBinEnabled          boolWrapper   `xml:"RecycleBinEnabled"`
 	RecycleBinUUID             string        `xml:"RecycleBinUUID"`
-	RecycleBinChanged          time.Time    `xml:"RecycleBinChanged"`
+	RecycleBinChanged          *time.Time    `xml:"RecycleBinChanged"`
 	EntryTemplatesGroup        string        `xml:"EntryTemplatesGroup"`
-	EntryTemplatesGroupChanged time.Time    `xml:"EntryTemplatesGroupChanged"`
+	EntryTemplatesGroupChanged *time.Time    `xml:"EntryTemplatesGroupChanged"`
 	HistoryMaxItems            int64         `xml:"HistoryMaxItems"`
 	HistoryMaxSize             int64         `xml:"HistoryMaxSize"`
 	LastSelectedGroup          string        `xml:"LastSelectedGroup"`
@@ -53,7 +53,7 @@ type MetaData struct {
 func NewMetaData () (*MetaData) {
 	meta := new(MetaData)
 	now := time.Now()
-	meta.MasterKeyChanged = now
+	*meta.MasterKeyChanged = now
 	meta.MasterKeyChangeRec = -1
 	meta.MasterKeyChangeForce = -1
 	return meta
@@ -97,25 +97,25 @@ type Group struct {
 
 //All metadata relating to times for groups and entries, such as last modification time
 type TimeData struct {
-	CreationTime         time.Time  `xml:"CreationTime"`
-	LastModificationTime time.Time  `xml:"LastModificationTime"`
-	LastAcessTime        time.Time  `xml:"LastAcessTime"`
-	ExpiryTime           time.Time  `xml:"ExpiryTime"`
+	CreationTime         *time.Time  `xml:"CreationTime"`
+	LastModificationTime *time.Time  `xml:"LastModificationTime"`
+	LastAcessTime        *time.Time  `xml:"LastAcessTime"`
+	ExpiryTime           *time.Time  `xml:"ExpiryTime"`
 	Expires              boolWrapper `xml:"Expires"`
 	UsageCount           int64       `xml:"UsageCount"`
-	LocationChanged      time.Time  `xml:"LocationChanged"`
+	LocationChanged      *time.Time  `xml:"LocationChanged"`
 }
 
 //NewTimeData returns a TimeData struct with good defaults (no expire time, all times set to now)
 func NewTimeData () (TimeData) {
 	data := TimeData{}
 	now := time.Now()
-	data.CreationTime = now
-	data.LastModificationTime = now
-	data.LastAcessTime = now
+	*data.CreationTime = now
+	*data.LastModificationTime = now
+	*data.LastAcessTime = now
 	data.Expires = false
 	data.UsageCount = 0
-	data.LocationChanged = now
+	*data.LocationChanged = now
 	return data
 }
 
@@ -210,5 +210,5 @@ type AutoTypeAssociation struct {
 type DeletedObjectData struct {
 	XMLName      xml.Name   `xml:"DeletedObject"`
 	UUID         string     `xml:"UUID"`
-	DeletionTime time.Time `xml:"DeletionTime"`
+	DeletionTime *time.Time `xml:"DeletionTime"`
 }

--- a/credentials.go
+++ b/credentials.go
@@ -20,6 +20,7 @@ type DBCredentials struct {
 func (c *DBCredentials) String() string {
 	return fmt.Sprintf("Hashed Passphrase: %x\nHashed Key: %x\nHashed Windows Auth: %x", c.Passphrase,c.Key,c.Windows)
 }
+
 func (c *DBCredentials) buildCompositeKey () ([]byte,error) {
 	hash := sha256.New()
 	if c.Passphrase != nil { //If the hashed password is provided
@@ -42,6 +43,7 @@ func (c *DBCredentials) buildCompositeKey () ([]byte,error) {
 	}
 	return hash.Sum(nil),nil
 }
+
 func (c *DBCredentials) buildMasterKey(db *Database) ([]byte, error) {
 	masterKey,err := c.buildCompositeKey()
 	if err != nil {
@@ -72,12 +74,13 @@ func (c *DBCredentials) buildMasterKey(db *Database) ([]byte, error) {
 	return masterKey, nil
 }
 
-// NewPasswordCredentials builds new DBCredentials from a Password string
+//NewPasswordCredentials builds a new DBCredentials from a Password string
 func NewPasswordCredentials(password string) *DBCredentials {
 	hashed := sha256.Sum256([]byte(password))
 	return &DBCredentials{Passphrase:hashed[:]}
 }
-//Returns the hashed key from a key file at location, parsing xml if needed
+
+//ParseKeyFile returns the hashed key from a key file at the path specified by location, parsing xml if needed
 func ParseKeyFile(location string) ([]byte,error) { 
 	r, err := regexp.Compile("<data>(.+)<\\/data>")
 	if err != nil {
@@ -97,7 +100,8 @@ func ParseKeyFile(location string) ([]byte,error) {
 	sum := sha256.Sum256(data)
 	return sum[:],nil
 }
-// NewKeyCredentials builds new DBCredentials from a key file
+
+// NewKeyCredentials builds new DBCredentials from a key file at the path specified by location
 func NewKeyCredentials(location string) (*DBCredentials, error) {
 	key,err := ParseKeyFile(location)
 	if err != nil {

--- a/credentials.go
+++ b/credentials.go
@@ -101,7 +101,7 @@ func ParseKeyFile(location string) ([]byte,error) {
 	return sum[:],nil
 }
 
-// NewKeyCredentials builds new DBCredentials from a key file at the path specified by location
+//NewKeyCredentials builds new DBCredentials from a key file at the path specified by location
 func NewKeyCredentials(location string) (*DBCredentials, error) {
 	key,err := ParseKeyFile(location)
 	if err != nil {

--- a/database.go
+++ b/database.go
@@ -35,7 +35,7 @@ func (db *Database) String() string {
 
 /* Goes through entire database and encryptes any values in entries with protected=true set. 
  * This should be called after decoding if you want to view plaintext password in an entry
- * 
+ * Warning: If you call this when entry values are already unlocked, it will cause them to be unreadable
  */
 func (db *Database) UnlockProtectedEntries() {
 	key := sha256.Sum256(db.Headers.ProtectedStreamKey)
@@ -43,7 +43,10 @@ func (db *Database) UnlockProtectedEntries() {
 	salsaManager.UnlockGroups(db.Content.Root.Groups)
 }
 
-//Goes through entire database and decryptes any values in entries with protected=true set. 
+/* Goes through entire database and decryptes any values in entries with protected=true set. 
+ * Warning: Do not call this if entries are already locked
+ * Warning: Encoding a database calls LockProtectedEntries automatically
+ */
 func (db *Database) LockProtectedEntries() {
 	key := sha256.Sum256(db.Headers.ProtectedStreamKey)
 	salsaManager := NewSalsaManager(key[:])

--- a/decoder.go
+++ b/decoder.go
@@ -15,9 +15,6 @@ import (
 	"reflect"
 )
 
-var BaseSignature = [...]byte{0x03, 0xd9, 0xa2, 0x9a}
-var VersionSignature = [...]byte{0x67, 0xfb, 0x4b, 0xb5}
-
 //Stores a reader which is expected to be in kdbx format
 type Decoder struct {
 	r io.Reader

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -11,13 +11,13 @@ func TestDecodeFile(t *testing.T) {
 		t.Fatalf("Failed to open keepass file: %s", err)
 	}
 
-	db := NewDatabase()
+	db := &Database{}
 	db.Credentials = NewPasswordCredentials("abcdefg12345678")
 	err = NewDecoder(file).Decode(db)
 	if err != nil {
 		t.Fatalf("Failed to decode file: %s", err)
 	}
-	
+
 	//Tests out the binary file in example.kdbx
 	binary := db.Content.Root.Groups[0].Groups[1].Entries[0].Binaries[0].Find(db.Content.Meta.Binaries)
 	if binary == nil {
@@ -30,7 +30,6 @@ func TestDecodeFile(t *testing.T) {
 	if str != "Hello world" {
 		t.Fatalf("Binary content was not as expected, expected: `Hello world`, received `%s`",str)
 	}
-	
 	db.UnlockProtectedEntries()
 	pw := db.Content.Root.Groups[0].Groups[0].Entries[0].GetPassword()
 	if string(pw) != "Password" {
@@ -56,7 +55,7 @@ func TestDecodeFile(t *testing.T) {
 		t.Fatalf("Failed to open keepass file: %s", err)
 	}
 
-	db = NewDatabase()
+	db = &Database{}
 	db.Credentials = NewPasswordCredentials("abcdefg12345678")
 	err = NewDecoder(file).Decode(db)
 	if err != nil {
@@ -78,5 +77,20 @@ func TestDecodeFile(t *testing.T) {
 			"Failed to decode url: should be 'http://github.com' not '%s'",
 			url,
 		)
+	}
+	
+	
+	//Creates a brand new kdbx file using only the library
+	newdb := NewDatabase()
+	newdb.Credentials = NewPasswordCredentials("password")
+	t.Log(newdb)
+	newfile,err := os.Create("examples/new.kdbx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	newencoder := NewEncoder(newfile)
+	err = newencoder.Encode(newdb)
+	if err != nil {
+		t.Fatal(err)
 	}
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -10,8 +10,9 @@ func TestDecodeFile(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to open keepass file: %s", err)
 	}
+	defer file.Close()
 
-	db := &Database{}
+	db := new(Database)
 	db.Credentials = NewPasswordCredentials("abcdefg12345678")
 	err = NewDecoder(file).Decode(db)
 	if err != nil {
@@ -50,14 +51,16 @@ func TestDecodeFile(t *testing.T) {
 	enc := NewEncoder(f)
 	enc.Encode(db)
 
-	file, err = os.Open("examples/tmp.kdbx")
+	tmpfile, err := os.Open("examples/tmp.kdbx")
 	if err != nil {
 		t.Fatalf("Failed to open keepass file: %s", err)
 	}
+	defer tmpfile.Close()
+	defer os.Remove("examples/tmp.kdbx")
 
-	db = &Database{}
+	db = new(Database)
 	db.Credentials = NewPasswordCredentials("abcdefg12345678")
-	err = NewDecoder(file).Decode(db)
+	err = NewDecoder(tmpfile).Decode(db)
 	if err != nil {
 		t.Fatalf("Failed to decode file: %s", err)
 	}
@@ -78,12 +81,10 @@ func TestDecodeFile(t *testing.T) {
 			url,
 		)
 	}
-	
-	
+
 	//Creates a brand new kdbx file using only the library
 	newdb := NewDatabase()
 	newdb.Credentials = NewPasswordCredentials("password")
-	t.Log(newdb)
 	newfile,err := os.Create("examples/new.kdbx")
 	if err != nil {
 		t.Fatal(err)
@@ -93,4 +94,5 @@ func TestDecodeFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Log("Please open example/new.kdbx with keepass2 to verify that it works")
 }

--- a/headers.go
+++ b/headers.go
@@ -4,7 +4,12 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"crypto/rand"
 )
+
+var AESCipherID = []byte{0x31, 0xC1, 0xF2, 0xE6, 0xBF, 0x71, 0x43, 0x50, 0xBE, 0x58, 0x05, 0x21, 0x6A, 0xFC, 0x5A, 0xFF}
+var GzipCompressionFlag = uint32(1)
+var SalsaInnerRandomStreamID = []byte{0x02,0x00,0x00,0x00}
 
 // FileHeaders holds the header information of the Keepass File.
 type FileHeaders struct {
@@ -20,7 +25,34 @@ type FileHeaders struct {
 	InnerRandomStreamID []byte // FieldID: 10
 }
 
-// 0: EndOfHeader
+//Creates a new FileHeaders with good defaults
+func NewFileHeaders () (*FileHeaders) {
+	h := new(FileHeaders)
+	
+	h.CipherID = []byte(AESCipherID)
+	h.CompressionFlags = GzipCompressionFlag
+	
+	h.MasterSeed = make([]byte,32)
+	rand.Read(h.MasterSeed)
+
+	h.TransformSeed = make([]byte,32)
+	rand.Read(h.TransformSeed)
+
+	h.TransformRounds = 6000
+
+	h.EncryptionIV = make([]byte,16)
+	rand.Read(h.EncryptionIV)
+
+	h.ProtectedStreamKey = make([]byte,32)
+	rand.Read(h.ProtectedStreamKey)
+	
+	h.StreamStartBytes = make([]byte,32)
+	rand.Read(h.StreamStartBytes)
+	
+	h.InnerRandomStreamID = SalsaInnerRandomStreamID
+	
+	return h
+}
 
 func (h FileHeaders) String() string {
 	return fmt.Sprintf(

--- a/signature.go
+++ b/signature.go
@@ -7,6 +7,18 @@ import (
 	"io"
 )
 
+//BaseSignature is the valid base signature for kdbx files
+var BaseSignature = [...]byte{0x03, 0xd9, 0xa2, 0x9a}
+
+//VersionSignature is the valid version signature for kdbx files
+var VersionSignature = [...]byte{0x67, 0xfb, 0x4b, 0xb5}
+
+//FileVersion is the most recent valid file version signature for kdbx files
+var FileVersion = [...]byte{0x01,0x00,0x03,0x00}
+
+//A full valid default signature struct for new databases
+var DefaultSig = FileSignature{BaseSignature,VersionSignature,FileVersion}
+
 // FileSignature holds the Keepass File Signature.
 // The first 4 Bytes are the Base Signature,
 // followed by 4 Bytes for the Version of the Format


### PR DESCRIPTION
Changed NewDatabase(), which now returns a new database with certain defaults configured so it can be encoded into a valid kdbx file immediately. This includes generating random bytes for certain header values, and setting the valid file signature.

Another test is added which generates a new database using this function. The file created with this function should be opened with keepass2 to verify the test. 

Various comments were added or changed for better godocs