### PR TITLE
Added  functionality and tests for binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ _testmain.go
 #ignore kdbx file created by test
 examples/tmp.kdbx
 examples/new.kdbx
+
+#ignore results of coverage test
+*.out

--- a/binary.go
+++ b/binary.go
@@ -22,15 +22,15 @@ func (bs Binaries) Find(id int) *Binary {
 	return nil
 }
 
-func (b *Binaries) Add (c []byte) *Binary {
-	binary := Binary{Compressed:boolWrapper(true)}
+func (b *Binaries) Add(c []byte) *Binary {
+	binary := Binary{Compressed: boolWrapper(true)}
 	if len(*b) == 0 {
 		binary.ID = 0
 	} else {
-		binary.ID = (*b)[len(*b)-1].ID+1
+		binary.ID = (*b)[len(*b)-1].ID + 1
 	}
 	binary.SetContent(c)
-	*b = append(*b,binary)
+	*b = append(*b, binary)
 	return &(*b)[len(*b)-1]
 }
 

--- a/binary.go
+++ b/binary.go
@@ -12,7 +12,7 @@ import (
 // Binaries Stores a slice of binaries in the metadata header of a database
 type Binaries []Binary
 
-//Find returns a reference to a binary with the same ID as id, or nil if none if found
+// Find returns a reference to a binary with the same ID as id, or nil if none if found
 func (bs Binaries) Find(id int) *Binary {
 	for i, _ := range bs {
 		if bs[i].ID == id {
@@ -22,7 +22,7 @@ func (bs Binaries) Find(id int) *Binary {
 	return nil
 }
 
-//Binary stores a binary found in the metadata header of a database
+// Binary stores a binary found in the metadata header of a database
 type Binary struct {
 	Content    []byte      `xml:",innerxml"`
 	ID         int         `xml:"ID,attr"`
@@ -33,7 +33,7 @@ func (b Binary) String() string {
 	return fmt.Sprintf("ID: %d, Compressed:%t, Content:%x", b.ID, b.Compressed, b.Content)
 }
 
-//GetContent returns a string which is the plaintext content of a binary, may return an error if something goes wrong in decoding from base64 or decompressing
+// GetContent returns a string which is the plaintext content of a binary
 func (b Binary) GetContent() (string, error) {
 	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(b.Content)))
 	_, err := base64.StdEncoding.Decode(decoded, b.Content)
@@ -55,7 +55,7 @@ func (b Binary) GetContent() (string, error) {
 	return string(decoded), nil
 }
 
-//SetContent encodes and (if Compressed=true) compresses c and sets b's content
+// SetContent encodes and (if Compressed=true) compresses c and sets b's content
 func (b *Binary) SetContent(c []byte) error {
 	buff := &bytes.Buffer{}
 	writer := base64.NewEncoder(base64.StdEncoding, buff)
@@ -71,7 +71,7 @@ func (b *Binary) SetContent(c []byte) error {
 	return nil
 }
 
-//CreateReference creates a reference with the same id as b with filename f
+// CreateReference creates a reference with the same id as b with filename f
 func (b Binary) CreateReference(f string) BinaryReference {
 	return NewBinaryReference(f, b.ID)
 }
@@ -84,7 +84,7 @@ type BinaryReference struct {
 	} `xml:"Value"`
 }
 
-//NewbinaryReference creates a new BinaryReference with the given name and id
+// NewbinaryReference creates a new BinaryReference with the given name and id
 func NewBinaryReference(name string, id int) BinaryReference {
 	ref := BinaryReference{}
 	ref.Name = name

--- a/binary.go
+++ b/binary.go
@@ -22,6 +22,18 @@ func (bs Binaries) Find(id int) *Binary {
 	return nil
 }
 
+func (b *Binaries) Add (c []byte) *Binary {
+	binary := Binary{Compressed:boolWrapper(true)}
+	if len(*b) == 0 {
+		binary.ID = 0
+	} else {
+		binary.ID = (*b)[len(*b)-1].ID+1
+	}
+	binary.SetContent(c)
+	*b = append(*b,binary)
+	return &(*b)[len(*b)-1]
+}
+
 // Binary stores a binary found in the metadata header of a database
 type Binary struct {
 	Content    []byte      `xml:",innerxml"`

--- a/binary_test.go
+++ b/binary_test.go
@@ -22,14 +22,14 @@ func TestBinary(t *testing.T) {
 	references := []BinaryReference{}
 	references = append(references, binary.CreateReference("example.txt"))
 	if references[0].Value.ID != 4 {
-		t.Fatal("Binary Reference ID is inncorrect. Should be 4, was %d", references[0].Value.ID)
+		t.Fatalf("Binary Reference ID is inncorrect. Should be 4, was %d", references[0].Value.ID)
 	}
 	if str, _ := references[0].Find(binaries).GetContent(); str != "test" {
-		t.Fatal("Binary Reference GetContent is inncorrect. Should be `test`, was '%s'", str)
+		t.Fatalf("Binary Reference GetContent is inncorrect. Should be `test`, was '%s'", str)
 	}
 
 	found := binaries.Find(binary2.ID)
 	if str, _ := found.GetContent(); str != "Hello world!" {
-		t.Fatal("Binary content from Find is inncorrect. Should be `Hello world!`, was '%s'", str)
+		t.Fatalf("Binary content from Find is inncorrect. Should be `Hello world!`, was '%s'", str)
 	}
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -9,14 +9,18 @@ var message string = "Hello World!"
 // Tests that binaries can set and get content correctly compressed or uncompressed
 func TestBinary(t *testing.T) {
 	binaries := Binaries{}
-
+	
 	binary := binaries.Add([]byte("test"))
 	binary.ID = 4
 
 	binary2 := binaries.Add([]byte("replace me"))
 	binary2.SetContent([]byte("Hello world!"))
 	if binary2.ID != 5 {
+		t.Fatalf("Binary2 assigned wrong id by binari.Add, should be 5, was %s",binary2.ID)
+	}
 
+	if binaries.Find(2) != nil {
+		t.Fatalf("Binaries.find for id 2 should be nil, wasn't")
 	}
 
 	references := []BinaryReference{}

--- a/binary_test.go
+++ b/binary_test.go
@@ -3,33 +3,35 @@ package gokeepasslib
 import (
 	"testing"
 )
+
 var message string = "Hello World!"
 
-func TestBinary (t *testing.T) {
-	binary := Binary{ID:0,Compressed:boolWrapper(true)}
+// Tests that binaries can set and get content correctly compressed or uncompressed
+func TestBinary(t *testing.T) {
+	binary := Binary{ID: 0, Compressed: boolWrapper(true)}
 	err := binary.SetContent([]byte(message))
 	if err != nil {
-		t.Fatalf("Error setting content: %s",err)
+		t.Fatalf("Error setting content: %s", err)
 	}
 	content, err := binary.GetContent()
 	if err != nil {
-		t.Fatalf("Error getting content: %s",err)
+		t.Fatalf("Error getting content: %s", err)
 	}
 	if content[:] != message[:] {
-		t.Fatalf("GetContent should be: `%s`, instead was `%s` ]",message,content)
+		t.Fatalf("GetContent should be: `%s`, instead was `%s` ]", message, content)
 	}
-	
+
 	//Same test, uncompressed
-	binary2 := Binary{ID:0,Compressed:boolWrapper(false)}
+	binary2 := Binary{ID: 0, Compressed: boolWrapper(false)}
 	err = binary2.SetContent([]byte(message))
 	if err != nil {
-		t.Fatalf("Error setting content: %s",err)
+		t.Fatalf("Error setting content: %s", err)
 	}
 	content, err = binary2.GetContent()
 	if err != nil {
-		t.Fatalf("Error getting content: %s",err)
+		t.Fatalf("Error getting content: %s", err)
 	}
 	if content[:] != message[:] {
-		t.Fatalf("GetContent should be: `%s`, instead was `%s` ]",message,content)
+		t.Fatalf("GetContent should be: `%s`, instead was `%s` ]", message, content)
 	}
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -20,16 +20,16 @@ func TestBinary(t *testing.T) {
 	}
 
 	references := []BinaryReference{}
-	references = append(references,binary.CreateReference("example.txt"))
+	references = append(references, binary.CreateReference("example.txt"))
 	if references[0].Value.ID != 4 {
-		t.Fatal("Binary Reference ID is inncorrect. Should be 4, was %d",references[0].Value.ID)
+		t.Fatal("Binary Reference ID is inncorrect. Should be 4, was %d", references[0].Value.ID)
 	}
-	if str,_ := references[0].Find(binaries).GetContent(); str != "test" {
-		t.Fatal("Binary Reference GetContent is inncorrect. Should be `test`, was '%s'",str)
+	if str, _ := references[0].Find(binaries).GetContent(); str != "test" {
+		t.Fatal("Binary Reference GetContent is inncorrect. Should be `test`, was '%s'", str)
 	}
-	
+
 	found := binaries.Find(binary2.ID)
-	if str,_ := found.GetContent(); str != "Hello world!" {
-		t.Fatal("Binary content from Find is inncorrect. Should be `Hello world!`, was '%s'",str)
+	if str, _ := found.GetContent(); str != "Hello world!" {
+		t.Fatal("Binary content from Find is inncorrect. Should be `Hello world!`, was '%s'", str)
 	}
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -8,30 +8,28 @@ var message string = "Hello World!"
 
 // Tests that binaries can set and get content correctly compressed or uncompressed
 func TestBinary(t *testing.T) {
-	binary := Binary{ID: 0, Compressed: boolWrapper(true)}
-	err := binary.SetContent([]byte(message))
-	if err != nil {
-		t.Fatalf("Error setting content: %s", err)
-	}
-	content, err := binary.GetContent()
-	if err != nil {
-		t.Fatalf("Error getting content: %s", err)
-	}
-	if content[:] != message[:] {
-		t.Fatalf("GetContent should be: `%s`, instead was `%s` ]", message, content)
+	binaries := Binaries{}
+
+	binary := binaries.Add([]byte("test"))
+	binary.ID = 4
+
+	binary2 := binaries.Add([]byte("replace me"))
+	binary2.SetContent([]byte("Hello world!"))
+	if binary2.ID != 5 {
+
 	}
 
-	//Same test, uncompressed
-	binary2 := Binary{ID: 0, Compressed: boolWrapper(false)}
-	err = binary2.SetContent([]byte(message))
-	if err != nil {
-		t.Fatalf("Error setting content: %s", err)
+	references := []BinaryReference{}
+	references = append(references,binary.CreateReference("example.txt"))
+	if references[0].Value.ID != 4 {
+		t.Fatal("Binary Reference ID is inncorrect. Should be 4, was %d",references[0].Value.ID)
 	}
-	content, err = binary2.GetContent()
-	if err != nil {
-		t.Fatalf("Error getting content: %s", err)
+	if str,_ := references[0].Find(binaries).GetContent(); str != "test" {
+		t.Fatal("Binary Reference GetContent is inncorrect. Should be `test`, was '%s'",str)
 	}
-	if content[:] != message[:] {
-		t.Fatalf("GetContent should be: `%s`, instead was `%s` ]", message, content)
+	
+	found := binaries.Find(binary2.ID)
+	if str,_ := found.GetContent(); str != "Hello world!" {
+		t.Fatal("Binary content from Find is inncorrect. Should be `Hello world!`, was '%s'",str)
 	}
 }

--- a/content.go
+++ b/content.go
@@ -79,6 +79,13 @@ type RootData struct {
 // NewRootData returns a RootData struct with good defaults
 func NewRootData() *RootData {
 	root := new(RootData)
+	group := Group{Name:"NewDatabase"}
+	group.Times = NewTimeData()
+	entry := Entry{}
+	entry.Times = NewTimeData()
+	entry.Values = append(entry.Values,ValueData{Key:"Title",Value:V{Content:"Sample Entry"},})
+	group.Entries = append(group.Entries,entry)
+	root.Groups = append(root.Groups,group)
 	return root
 }
 

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -92,6 +92,11 @@ func TestDecodeFile(t *testing.T) {
 func TestCreateNewFile(t *testing.T) {
 	//Creates a brand new kdbx file using only the library
 	newdb := NewDatabase()
+	
+	if newdb.Content.Root.Groups[0].Entries[0].GetTitle() != "Sample Entry" {
+		t.Fatalf("NewRootData() seemed to not work, title should be 'Sample Entry', was %s",newdb.Content.Root.Groups[0].Entries[0].GetTitle())
+	}
+	
 	newdb.Credentials = NewPasswordCredentials("password")
 	newfile, err := os.Create("examples/new.kdbx")
 	if err != nil {


### PR DESCRIPTION
Added some methods to binaries and binary references to make them more usable (like being able to set data without worrying about encoding or compression). Also fairly extensive test file added for them. 

Also changed NewRootData to return a sample group and entry like you get when your create a database with keepass, and a test for this.