### PR TITLE
Refactored file signature to be more accurate and follow go conventiosn

### DIFF
--- a/decoder.go
+++ b/decoder.go
@@ -15,12 +15,11 @@ type Decoder struct {
 	r io.Reader
 }
 
-func (d *Decoder) Decode(db *Database) error {
-	s, err := ReadSignature(d.r)
-	if err != nil {
-		return err
+func (d *Decoder) Decode(db *Database) (err error) {
+	db.Signature = new(FileSignature)
+	if err = db.Signature.ReadFrom(d.r); err != nil {
+		return  err
 	}
-	db.Signature = s
 
 	db.Headers = new(FileHeaders)
 	err = db.Headers.ReadFrom(d.r)

--- a/decoder.go
+++ b/decoder.go
@@ -22,8 +22,7 @@ func (d *Decoder) Decode(db *Database) (err error) {
 	}
 
 	db.Headers = new(FileHeaders)
-	err = db.Headers.ReadFrom(d.r)
-	if err != nil {
+	if err = db.Headers.ReadFrom(d.r); err != nil {
 		return err
 	}
 

--- a/decoder.go
+++ b/decoder.go
@@ -18,7 +18,7 @@ type Decoder struct {
 func (d *Decoder) Decode(db *Database) (err error) {
 	db.Signature = new(FileSignature)
 	if err = db.Signature.ReadFrom(d.r); err != nil {
-		return  err
+		return err
 	}
 
 	db.Headers = new(FileHeaders)

--- a/encoder.go
+++ b/encoder.go
@@ -27,12 +27,12 @@ func (e *Encoder) Encode(db *Database) (err error) {
 	if err = db.Headers.WriteTo(e.w); err != nil {
 		return err
 	}
-	
+
 	//Write database content, encrypted
 	if err = e.writeData(db); err != nil {
 		return err
 	}
-	
+
 	return nil
 }
 

--- a/encoder.go
+++ b/encoder.go
@@ -17,8 +17,23 @@ type Encoder struct {
 }
 
 // Encode writes db to e's internal writer
-func (e *Encoder) Encode(db *Database) error {
-	return e.writeData(db)
+func (e *Encoder) Encode(db *Database) (err error) {
+	//Writes file signature (tells program it's a kdbx file of x version)
+	if err = db.Signature.WriteTo(e.w); err != nil {
+		return err
+	}
+
+	//Writes headers of database
+	if err = db.Headers.WriteTo(e.w); err != nil {
+		return err
+	}
+	
+	//Write database content, encrypted
+	if err = e.writeData(db); err != nil {
+		return err
+	}
+	
+	return nil
 }
 
 // NewEncoder creates a new encoder with writer w, identical to gokeepasslib.Encoder{w}
@@ -79,16 +94,6 @@ func (e *Encoder) writeData(db *Database) error {
 	}
 	encrypted := make([]byte, len(hashData))
 	mode.CryptBlocks(encrypted, hashData)
-
-	//Writes file signature (tells program it's a kdbx file of x version)
-	if err = db.Signature.WriteTo(e.w); err != nil {
-		return err
-	}
-
-	//Writes headers of database
-	if err = db.Headers.WriteTo(e.w); err != nil {
-		return err
-	}
 
 	//Writes the encrypted database content
 	if _, err = e.w.Write(encrypted); err != nil {

--- a/encoder.go
+++ b/encoder.go
@@ -81,20 +81,17 @@ func (e *Encoder) writeData(db *Database) error {
 	mode.CryptBlocks(encrypted, hashData)
 
 	//Writes file signature (tells program it's a kdbx file of x version)
-	err = db.Signature.WriteSignature(e.w)
-	if err != nil {
+	if err = db.Signature.WriteTo(e.w); err != nil {
 		return err
 	}
 
 	//Writes headers of database
-	err = db.Headers.WriteTo(e.w)
-	if err != nil {
+	if err = db.Headers.WriteTo(e.w); err != nil {
 		return err
 	}
 
 	//Writes the encrypted database content
-	_, err = e.w.Write(encrypted)
-	if err != nil {
+	if _, err = e.w.Write(encrypted); err != nil {
 		return err
 	}
 

--- a/signature.go
+++ b/signature.go
@@ -12,9 +12,6 @@ var BaseSignature = [...]byte{0x03, 0xd9, 0xa2, 0x9a}
 //VersionSignature is the valid version signature for kdbx files
 var VersionSignature = [...]byte{0x67, 0xfb, 0x4b, 0xb5}
 
-//FileVersion is the most recent valid file version signature for kdbx files
-var FileVersion = [...]byte{0x01, 0x00, 0x03, 0x00}
-
 //MajorVersion
 const MajorVersion = 3
 

--- a/signature.go
+++ b/signature.go
@@ -10,7 +10,7 @@ import (
 var BaseSignature = [...]byte{0x03, 0xd9, 0xa2, 0x9a}
 
 //VersionSignature is the valid version signature for kdbx files
-var VersionSignature = [...]byte{0x67, 0xfb, 0x4b, 0xb5}
+var SecondarySignature = [...]byte{0x67, 0xfb, 0x4b, 0xb5}
 
 //MajorVersion
 const MajorVersion = 3
@@ -19,15 +19,16 @@ const MajorVersion = 3
 const MinorVersion = 1
 
 //A full valid default signature struct for new databases
-var DefaultSig = FileSignature{BaseSignature, VersionSignature,MinorVersion,MajorVersion}
+var DefaultSig = FileSignature{BaseSignature, SecondarySignature, MinorVersion, MajorVersion}
 
 type ErrInvalidSignature struct {
-	Name string
-	Is interface{}
+	Name     string
+	Is       interface{}
 	Shouldbe interface{}
 }
-func (e ErrInvalidSignature) Error () string {
-	return fmt.Sprintf("gokeepasslib: invalid signature. %s is %x. Should be %x",e.Name,e.Is,e.Shouldbe)
+
+func (e ErrInvalidSignature) Error() string {
+	return fmt.Sprintf("gokeepasslib: invalid signature. %s is %x. Should be %x", e.Name, e.Is, e.Shouldbe)
 }
 
 // FileSignature holds the Keepass File Signature.
@@ -35,32 +36,32 @@ func (e ErrInvalidSignature) Error () string {
 // followed by 4 Bytes for the Version of the Format
 // which is followed by 4 Bytes for the File Version
 type FileSignature struct {
-	BaseSignature    [4]byte
-	VersionSignature [4]byte
-	MinorVersion     uint16
-	MajorVersion     uint16
+	BaseSignature      [4]byte
+	SecondarySignature [4]byte
+	MinorVersion       uint16
+	MajorVersion       uint16
 }
 
 func (s FileSignature) String() string {
-	return fmt.Sprintf("Base: %x, Version: %x, Format Version: %d.%d",
+	return fmt.Sprintf("Base: %x, Secondary: %x, Format Version: %d.%d",
 		s.BaseSignature,
-		s.VersionSignature,
+		s.SecondarySignature,
 		s.MajorVersion,
 		s.MinorVersion,
 	)
 }
 func (s FileSignature) Validate() error {
 	if s.BaseSignature != BaseSignature {
-		return ErrInvalidSignature{"BaseSignature",s.BaseSignature,BaseSignature}
+		return ErrInvalidSignature{"Base Signature", s.BaseSignature, BaseSignature}
 	}
-	if s.VersionSignature != VersionSignature {
-		return ErrInvalidSignature{"VersionSignature",s.VersionSignature,VersionSignature}
+	if s.SecondarySignature != SecondarySignature {
+		return ErrInvalidSignature{"Secondary Signature", s.SecondarySignature, SecondarySignature}
 	}
 	if s.MinorVersion != MinorVersion {
-		return ErrInvalidSignature{"MinorVersion",s.MinorVersion,MinorVersion}
+		return ErrInvalidSignature{"Minor Version", s.MinorVersion, MinorVersion}
 	}
 	if s.MajorVersion != MajorVersion {
-		return ErrInvalidSignature{"MajorVersion",s.MajorVersion,MajorVersion}
+		return ErrInvalidSignature{"Major Version", s.MajorVersion, MajorVersion}
 	}
 	return nil
 }


### PR DESCRIPTION
Changed signature struct to have Base Signature, Secondary Signature, Minor Version, Major version as kdbx files have. Allows users to view the format version of their kdbx file (currently 3.1). Also follows the WriteTo, ReadFrom convention from Headers.

Error handling for invalid signature is also easier (user can see what part of the signature is invalid and what it should be)