### PR TITLE
fix constant overflows int error

### DIFF
--- a/salsa.go
+++ b/salsa.go
@@ -15,7 +15,7 @@ type SalsaManager struct {
 	State        []uint32
 	blockUsed    int
 	block        []byte
-	counterWords [2]int
+	counterWords [2]uint32
 	currentBlock []byte
 }
 
@@ -139,7 +139,7 @@ func (s *SalsaManager) Pack(payload []byte) string {
 
 func (s *SalsaManager) reset() {
 	s.blockUsed = 64
-	s.counterWords = [2]int{0, 0}
+	s.counterWords = [2]uint32{0, 0}
 }
 
 func (s *SalsaManager) incrementCounter() {


### PR DESCRIPTION
When I try to build on Arch Linux with go version go1.8 linux/386 I got the following error:
```
% go build
# _/tmp/gokeepasslib
./salsa.go:146: constant 4294967295 overflows int
./salsa.go:148: constant 4294967295 overflows int
```
I'm not sure if it's a 32-bit related error or my go tool chain version. Tests seem to pass and tobischo/kp2 is still working fine with this patch.