### PR TITLE
Fix bug where Gzip writer was not Close()d before data was used

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -79,7 +79,9 @@ func (b *Binary) SetContent(c []byte) error {
 	if err != nil {
 		return err
 	}
-	writer.Close()
+	if err := writer.Close(); err != nil {
+		return err
+	}
 	b.Content = buff.Bytes()
 	return nil
 }

--- a/binary_test.go
+++ b/binary_test.go
@@ -16,7 +16,7 @@ func TestBinary(t *testing.T) {
 	binary2 := binaries.Add([]byte("replace me"))
 	binary2.SetContent([]byte("Hello world!"))
 	if binary2.ID != 5 {
-		t.Fatalf("Binary2 assigned wrong id by binaries.Add, should be 5, was %s", binary2.ID)
+		t.Fatalf("Binary2 assigned wrong id by binaries.Add, should be 5, was %d", binary2.ID)
 	}
 
 	if binaries.Find(2) != nil {

--- a/content_test.go
+++ b/content_test.go
@@ -30,7 +30,7 @@ func TestUUID(t *testing.T) {
 	one := UUID{}
 	err := one.UnmarshalText([]byte("rGnBe1gIikK89aZD6n/plA=="))
 	if err != nil {
-		t.Fatalf("Error unmarshaling uuid", err)
+		t.Fatalf("Error unmarshaling uuid: %s", err.Error())
 	}
 	mar, err := one.MarshalText()
 	if err != nil {

--- a/encoder.go
+++ b/encoder.go
@@ -52,13 +52,15 @@ func (e *Encoder) writeData(db *Database) error {
 	if db.Headers.CompressionFlags == GzipCompressionFlag { //If database header says to compress with gzip, compress xml data and put into block form
 		b := new(bytes.Buffer)
 		w := gzip.NewWriter(b)
-		defer w.Close()
 
 		if _, err = w.Write(xmlData); err != nil {
 			return err
 		}
 
-		if err = w.Flush(); err != nil {
+		// Close() needs to be explicitly called to write Gzip stream footer,
+		// Flush() is not enough. some gzip decoders treat missing footer as error
+		// while some don't). internally Close() also does flush.
+		if err = w.Close(); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
Fixes #23

The `Flush()` is not needed anymore. I tested my database now working against Keepass on Windows and KeePassDroid.

There is also Gzip writing in https://github.com/tobischo/gokeepasslib/blob/a6351206307a10fe80f1544fa2bbcbbf0d7d32d2/binary.go#L83 but it properly calls `Close()` before using. However, it does not check error return of `Close()`. Do you think we should check it as well?