### PR TITLE
Treat Bool values case-insensitively when Unmarshaling.

### DIFF
--- a/wrappers/bool.go
+++ b/wrappers/bool.go
@@ -1,6 +1,9 @@
 package wrappers
 
-import "encoding/xml"
+import (
+	"encoding/xml"
+	"strings"
+)
 
 // BoolWrapper is a bool wrapper that provides xml marshaling and unmarshaling
 type BoolWrapper bool
@@ -21,7 +24,7 @@ func (b *BoolWrapper) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error
 	d.DecodeElement(&val, &start)
 
 	*b = false
-	if val == "True" {
+	if strings.ToLower(val) == "true" {
 		*b = true
 	}
 
@@ -41,7 +44,7 @@ func (b *BoolWrapper) MarshalXMLAttr(name xml.Name) (xml.Attr, error) {
 // UnmarshalXMLAttr decodes a single XML attribute
 func (b *BoolWrapper) UnmarshalXMLAttr(attr xml.Attr) error {
 	*b = false
-	if attr.Value == "True" {
+	if strings.ToLower(attr.Value) == "true" {
 		*b = true
 	}
 

--- a/wrappers_test.go
+++ b/wrappers_test.go
@@ -1,6 +1,7 @@
 package gokeepasslib
 
 import (
+	"encoding/xml"
 	"testing"
 	"time"
 
@@ -95,6 +96,123 @@ func TestTimeWrapperUnmarshalText(t *testing.T) {
 			if !timeWrap.Time.Equal(c.expValue) {
 				t.Errorf("Did not receive expected value '%+v', received: '%+v'", c.expValue, *timeWrap)
 			}
+		})
+	}
+}
+
+func TestBoolWrapperUnmarshal(t *testing.T) {
+	cases := []struct {
+		title    string
+		value    string
+		expValue bool
+		expErr   error
+	}{
+		{
+			title:    "lowercase true",
+			value:    `<Wrap><Val>true</Val></Wrap>`,
+			expValue: true,
+			expErr:   nil,
+		},
+		{
+			title:    "mixedcase true",
+			value:    `<Wrap><Val>TrUe</Val></Wrap>`,
+			expValue: true,
+			expErr:   nil,
+		},
+		{
+			title:    "lowercase false",
+			value:    `<Wrap><Val>false</Val></Wrap>`,
+			expValue: false,
+			expErr:   nil,
+		},
+		{
+			title:    "mixedcase false",
+			value:    `<Wrap><Val>FaLsE</Val></Wrap>`,
+			expValue: false,
+			expErr:   nil,
+		},
+		{
+			title:    "neither true nor false defaults to false",
+			value:    `<Wrap><Val>neither</Val></Wrap>`,
+			expValue: false,
+			expErr:   nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			var x struct {
+				Val BoolWrapper `xml:"Val"`
+			}
+			err := xml.Unmarshal([]byte(c.value), &x)
+
+			if err != c.expErr {
+				t.Fatalf("Did not receive expected error %+v, received %+v", c.expErr, err)
+			}
+			if bool(x.Val) != c.expValue {
+				t.Errorf("Did not receive expected value '%+v', received: '%+v'", c.expValue, x.Val)
+			}
+
+		})
+	}
+}
+
+func TestBoolWrapperUnmarshalAttr(t *testing.T) {
+	cases := []struct {
+		title    string
+		value    string
+		expValue bool
+		expErr   error
+	}{
+		{
+			title:    "lowercase true",
+			value:    `<Wrap><Val v="true"></Val></Wrap>`,
+			expValue: true,
+			expErr:   nil,
+		},
+		{
+			title:    "mixedcase true",
+			value:    `<Wrap><Val v="TrUe"></Val></Wrap>`,
+			expValue: true,
+			expErr:   nil,
+		},
+		{
+			title:    "lowercase false",
+			value:    `<Wrap><Val v="false"></Val></Wrap>`,
+			expValue: false,
+			expErr:   nil,
+		},
+		{
+			title:    "mixedcase false",
+			value:    `<Wrap><Val v="FaLsE"></Val></Wrap>`,
+			expValue: false,
+			expErr:   nil,
+		},
+		{
+			title:    "neither true nor false defaults to false",
+			value:    `<Wrap><Val v="neither"></Val></Wrap>`,
+			expValue: false,
+			expErr:   nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.title, func(t *testing.T) {
+			var x struct {
+				Val struct {
+					Content string      `xml:",chardata"`
+					V       BoolWrapper `xml:"v,attr,omitempty"`
+				}
+			}
+			err := xml.Unmarshal([]byte(c.value), &x)
+
+			if err != c.expErr {
+				t.Fatalf("Did not receive expected error %+v, received %+v", c.expErr, err)
+			}
+			if bool(x.Val.V) != c.expValue {
+				t.Errorf("Did not receive expected value '%+v', received: '%+v'", c.expValue, x.Val.V)
+			}
+
 		})
 	}
 }


### PR DESCRIPTION
keepassx and keepasxc write them out all lower case, but the existing code
is looking for "True" and "False".