### PR TITLE
Read binaries as bytes instead of string

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -65,8 +65,8 @@ func (bs *Binaries) Add(c []byte) *Binary {
 	return &(*bs)[len(*bs)-1]
 }
 
-// GetContent returns a string which is the plaintext content of a binary
-func (b Binary) GetContent() (string, error) {
+// GetContentBytes returns a bytes array which is the content of a binary
+func (b Binary) GetContentBytes() ([]byte, error) {
 	// Check for base64 content (KDBX 3.1), if it fail try with KDBX 4
 	decoded := make([]byte, base64.StdEncoding.DecodedLen(len(b.Content)))
 	_, err := base64.StdEncoding.Decode(decoded, b.Content)
@@ -78,16 +78,34 @@ func (b Binary) GetContent() (string, error) {
 	if b.Compressed.Bool {
 		reader, err := gzip.NewReader(bytes.NewReader(decoded))
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		defer reader.Close()
 		bts, err := ioutil.ReadAll(reader)
 		if err != nil && err != io.ErrUnexpectedEOF {
-			return "", err
+			return nil, err
 		}
-		return string(bts), nil
+		return bts, nil
 	}
-	return string(decoded), nil
+	return decoded, nil
+}
+
+// GetContentString returns a string which is the plaintext content of a binary
+func (b Binary) GetContentString() (string, error) {
+	data, err := b.GetContentBytes()
+
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}
+
+// GetContent returns a string which is the plaintext content of a binary
+//
+// Deprecated: use GetContentString() instead
+func (b Binary) GetContent() (string, error) {
+	return b.GetContentString()
 }
 
 // SetContent encodes and (if Compressed=true) compresses c and sets b's content

--- a/binary_test.go
+++ b/binary_test.go
@@ -30,12 +30,18 @@ func TestBinary(t *testing.T) {
 	if references[0].Value.ID != 4 {
 		t.Fatalf("Binary Reference ID is incorrect. Should be 4, was %d", references[0].Value.ID)
 	}
-	if str, _ := references[0].Find(db).GetContent(); str != "test" {
-		t.Fatalf("Binary Reference GetContent is incorrect. Should be `test`, was '%s'", str)
+	if data, _ := references[0].Find(db).GetContentBytes(); string(data) != "test" {
+		t.Fatalf("Binary Reference GetContentBytes is incorrect. Should be `test`, was '%s'", string(data))
+	}
+	if str, _ := references[0].Find(db).GetContentString(); str != "test" {
+		t.Fatalf("Binary Reference GetContentString is incorrect. Should be `test`, was '%s'", str)
 	}
 
 	found := binaries.Find(binary2.ID)
-	if str, _ := found.GetContent(); str != "Hello world!" {
+	if data, _ := found.GetContentBytes(); string(data) != "Hello world!" {
+		t.Fatalf("Binary content from Find is inncorrect. Should be `Hello world!`, was '%s'", string(data))
+	}
+	if str, _ := found.GetContentString(); str != "Hello world!" {
 		t.Fatalf("Binary content from Find is inncorrect. Should be `Hello world!`, was '%s'", str)
 	}
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -127,7 +127,7 @@ func TestDecodeFile(t *testing.T) {
 			if binary == nil {
 				t.Fatalf("Failed to find binary")
 			}
-			str, err := binary.GetContent()
+			str, err := binary.GetContentString()
 			if err != nil {
 				t.Fatal("Error getting content from binary: ", err, str)
 			}


### PR DESCRIPTION
I suggest to replace string return parameter of GetContent() with bytes array because it is much more common case since most of users store some binary files here.