### PR TITLE
chore(deps): update crypto to 0.8.0, sys to 0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,8 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 // indirect
+	golang.org/x/crypto v0.8.0 // indirect
 	golang.org/x/exp v0.0.0-20230105202349-8879d0199aa3 // indirect
-	golang.org/x/sys v0.1.0 // indirect
+	golang.org/x/sys v0.7.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -19,12 +19,16 @@ github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKs
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90 h1:Y/gsMcFOcR+6S6f3YeMKl5g+dZMEWqcz5Czj/GWYbkM=
 golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.8.0 h1:pd9TJtTueMTVQXzk8E2XESSMQDj/U7OUu0PqJqPXQjQ=
+golang.org/x/crypto v0.8.0/go.mod h1:mRqEX+O9/h5TFCrQhkgjo2yKi0yYA+9ecGkdQoHrywE=
 golang.org/x/exp v0.0.0-20230105202349-8879d0199aa3 h1:fJwx88sMf5RXwDwziL0/Mn9Wqs+efMSo/RYcL+37W9c=
 golang.org/x/exp v0.0.0-20230105202349-8879d0199aa3/go.mod h1:CxIveKay+FTh1D0yPZemJVgC/95VzuuOLq5Qi4xnoYc=
 golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2 h1:wM1k/lXfpc5HdkJJyW9GELpd8ERGdnh8sMGL6Gzq3Ho=
 golang.org/x/sys v0.0.0-20220909162455-aba9fc2a8ff2/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.7.0 h1:3jlCCIQZPdOYu1h8BkNvLz8Kgwtae2cagcG/VamtZRU=
+golang.org/x/sys v0.7.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/vendor/golang.org/x/sys/cpu/cpu_gccgo_x86.c
+++ b/vendor/golang.org/x/sys/cpu/cpu_gccgo_x86.c
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build (386 || amd64 || amd64p32) && gccgo
 // +build 386 amd64 amd64p32
 // +build gccgo
 

--- a/vendor/golang.org/x/sys/cpu/cpu_linux_arm64.go
+++ b/vendor/golang.org/x/sys/cpu/cpu_linux_arm64.go
@@ -4,6 +4,11 @@
 
 package cpu
 
+import (
+	"strings"
+	"syscall"
+)
+
 // HWCAP/HWCAP2 bits. These are exposed by Linux.
 const (
 	hwcap_FP       = 1 << 0
@@ -32,10 +37,45 @@ const (
 	hwcap_ASIMDFHM = 1 << 23
 )
 
+// linuxKernelCanEmulateCPUID reports whether we're running
+// on Linux 4.11+. Ideally we'd like to ask the question about
+// whether the current kernel contains
+// https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=77c97b4ee21290f5f083173d957843b615abbff2
+// but the version number will have to do.
+func linuxKernelCanEmulateCPUID() bool {
+	var un syscall.Utsname
+	syscall.Uname(&un)
+	var sb strings.Builder
+	for _, b := range un.Release[:] {
+		if b == 0 {
+			break
+		}
+		sb.WriteByte(byte(b))
+	}
+	major, minor, _, ok := parseRelease(sb.String())
+	return ok && (major > 4 || major == 4 && minor >= 11)
+}
+
 func doinit() {
 	if err := readHWCAP(); err != nil {
-		// failed to read /proc/self/auxv, try reading registers directly
-		readARM64Registers()
+		// We failed to read /proc/self/auxv. This can happen if the binary has
+		// been given extra capabilities(7) with /bin/setcap.
+		//
+		// When this happens, we have two options. If the Linux kernel is new
+		// enough (4.11+), we can read the arm64 registers directly which'll
+		// trap into the kernel and then return back to userspace.
+		//
+		// But on older kernels, such as Linux 4.4.180 as used on many Synology
+		// devices, calling readARM64Registers (specifically getisar0) will
+		// cause a SIGILL and we'll die. So for older kernels, parse /proc/cpuinfo
+		// instead.
+		//
+		// See golang/go#57336.
+		if linuxKernelCanEmulateCPUID() {
+			readARM64Registers()
+		} else {
+			readLinuxProcCPUInfo()
+		}
 		return
 	}
 

--- a/vendor/golang.org/x/sys/cpu/endian_big.go
+++ b/vendor/golang.org/x/sys/cpu/endian_big.go
@@ -1,0 +1,11 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build armbe || arm64be || m68k || mips || mips64 || mips64p32 || ppc || ppc64 || s390 || s390x || shbe || sparc || sparc64
+// +build armbe arm64be m68k mips mips64 mips64p32 ppc ppc64 s390 s390x shbe sparc sparc64
+
+package cpu
+
+// IsBigEndian records whether the GOARCH's byte order is big endian.
+const IsBigEndian = true

--- a/vendor/golang.org/x/sys/cpu/endian_little.go
+++ b/vendor/golang.org/x/sys/cpu/endian_little.go
@@ -1,0 +1,11 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build 386 || amd64 || amd64p32 || alpha || arm || arm64 || loong64 || mipsle || mips64le || mips64p32le || nios2 || ppc64le || riscv || riscv64 || sh
+// +build 386 amd64 amd64p32 alpha arm arm64 loong64 mipsle mips64le mips64p32le nios2 ppc64le riscv riscv64 sh
+
+package cpu
+
+// IsBigEndian records whether the GOARCH's byte order is big endian.
+const IsBigEndian = false

--- a/vendor/golang.org/x/sys/cpu/hwcap_linux.go
+++ b/vendor/golang.org/x/sys/cpu/hwcap_linux.go
@@ -24,6 +24,21 @@ var hwCap uint
 var hwCap2 uint
 
 func readHWCAP() error {
+	// For Go 1.21+, get auxv from the Go runtime.
+	if a := getAuxv(); len(a) > 0 {
+		for len(a) >= 2 {
+			tag, val := a[0], uint(a[1])
+			a = a[2:]
+			switch tag {
+			case _AT_HWCAP:
+				hwCap = val
+			case _AT_HWCAP2:
+				hwCap2 = val
+			}
+		}
+		return nil
+	}
+
 	buf, err := ioutil.ReadFile(procAuxv)
 	if err != nil {
 		// e.g. on android /proc/self/auxv is not accessible, so silently

--- a/vendor/golang.org/x/sys/cpu/parse.go
+++ b/vendor/golang.org/x/sys/cpu/parse.go
@@ -1,0 +1,43 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cpu
+
+import "strconv"
+
+// parseRelease parses a dot-separated version number. It follows the semver
+// syntax, but allows the minor and patch versions to be elided.
+//
+// This is a copy of the Go runtime's parseRelease from
+// https://golang.org/cl/209597.
+func parseRelease(rel string) (major, minor, patch int, ok bool) {
+	// Strip anything after a dash or plus.
+	for i := 0; i < len(rel); i++ {
+		if rel[i] == '-' || rel[i] == '+' {
+			rel = rel[:i]
+			break
+		}
+	}
+
+	next := func() (int, bool) {
+		for i := 0; i < len(rel); i++ {
+			if rel[i] == '.' {
+				ver, err := strconv.Atoi(rel[:i])
+				rel = rel[i+1:]
+				return ver, err == nil
+			}
+		}
+		ver, err := strconv.Atoi(rel)
+		rel = ""
+		return ver, err == nil
+	}
+	if major, ok = next(); !ok || rel == "" {
+		return
+	}
+	if minor, ok = next(); !ok || rel == "" {
+		return
+	}
+	patch, ok = next()
+	return
+}

--- a/vendor/golang.org/x/sys/cpu/proc_cpuinfo_linux.go
+++ b/vendor/golang.org/x/sys/cpu/proc_cpuinfo_linux.go
@@ -1,0 +1,54 @@
+// Copyright 2022 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build linux && arm64
+// +build linux,arm64
+
+package cpu
+
+import (
+	"errors"
+	"io"
+	"os"
+	"strings"
+)
+
+func readLinuxProcCPUInfo() error {
+	f, err := os.Open("/proc/cpuinfo")
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var buf [1 << 10]byte // enough for first CPU
+	n, err := io.ReadFull(f, buf[:])
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return err
+	}
+	in := string(buf[:n])
+	const features = "\nFeatures	: "
+	i := strings.Index(in, features)
+	if i == -1 {
+		return errors.New("no CPU features found")
+	}
+	in = in[i+len(features):]
+	if i := strings.Index(in, "\n"); i != -1 {
+		in = in[:i]
+	}
+	m := map[string]*bool{}
+
+	initOptions() // need it early here; it's harmless to call twice
+	for _, o := range options {
+		m[o.Name] = o.Feature
+	}
+	// The EVTSTRM field has alias "evstrm" in Go, but Linux calls it "evtstrm".
+	m["evtstrm"] = &ARM64.HasEVTSTRM
+
+	for _, f := range strings.Fields(in) {
+		if p, ok := m[f]; ok {
+			*p = true
+		}
+	}
+	return nil
+}

--- a/vendor/golang.org/x/sys/cpu/runtime_auxv.go
+++ b/vendor/golang.org/x/sys/cpu/runtime_auxv.go
@@ -1,0 +1,16 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package cpu
+
+// getAuxvFn is non-nil on Go 1.21+ (via runtime_auxv_go121.go init)
+// on platforms that use auxv.
+var getAuxvFn func() []uintptr
+
+func getAuxv() []uintptr {
+	if getAuxvFn == nil {
+		return nil
+	}
+	return getAuxvFn()
+}

--- a/vendor/golang.org/x/sys/cpu/runtime_auxv_go121.go
+++ b/vendor/golang.org/x/sys/cpu/runtime_auxv_go121.go
@@ -1,0 +1,19 @@
+// Copyright 2023 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build go1.21
+// +build go1.21
+
+package cpu
+
+import (
+	_ "unsafe" // for linkname
+)
+
+//go:linkname runtime_getAuxv runtime.getAuxv
+func runtime_getAuxv() []uintptr
+
+func init() {
+	getAuxvFn = runtime_getAuxv
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -22,14 +22,14 @@ github.com/pmezard/go-difflib/difflib
 # github.com/stretchr/testify v1.8.1
 ## explicit; go 1.13
 github.com/stretchr/testify/assert
-# golang.org/x/crypto v0.0.0-20220829220503-c86fa9a7ed90
+# golang.org/x/crypto v0.8.0
 ## explicit; go 1.17
 golang.org/x/crypto/blake2b
 # golang.org/x/exp v0.0.0-20230105202349-8879d0199aa3
 ## explicit; go 1.18
 golang.org/x/exp/constraints
 golang.org/x/exp/slices
-# golang.org/x/sys v0.1.0
+# golang.org/x/sys v0.7.0
 ## explicit; go 1.17
 golang.org/x/sys/cpu
 # gopkg.in/yaml.v3 v3.0.1


### PR DESCRIPTION
hey, I'd like to build an app with this library, but I've noticed that the `sys` package was quite outdated, thus a security risk. I've run the automated tests and they turned out OK.