### PR TITLE
refactor: remove magic numbers, replace deprecated code & remove redundant cast

### DIFF
--- a/binary.go
+++ b/binary.go
@@ -5,10 +5,8 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"io"
-	"io/ioutil"
-
 	w "github.com/tobischo/gokeepasslib/v3/wrappers"
+	"io"
 )
 
 // Binaries Stores a slice of binaries in the metadata header of a database
@@ -109,7 +107,7 @@ func (b Binary) GetContentBytes() ([]byte, error) {
 			return nil, err
 		}
 		defer reader.Close()
-		bts, err := ioutil.ReadAll(reader)
+		bts, err := io.ReadAll(reader)
 		if err != nil && err != io.ErrUnexpectedEOF {
 			return nil, err
 		}

--- a/blocks.go
+++ b/blocks.go
@@ -9,11 +9,10 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 // Block size of 1MB - https://keepass.info/help/kb/kdbx_4.html#dataauth
-const blockSplitRate = 1048576
+const blockSplitRate = 1 * 1024 * 1024
 
 type BlockHMACBuilder struct {
 	baseKey []byte
@@ -49,7 +48,7 @@ func (b *BlockHMACBuilder) BuildHMAC(index uint64, length uint32, data []byte) [
 func decomposeContentBlocks4(r io.Reader, masterSeed []byte, transformedKey []byte) ([]byte, error) {
 	var contentData []byte
 	// Get all the content
-	content, err := ioutil.ReadAll(r)
+	content, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +97,7 @@ func decomposeContentBlocks4(r io.Reader, masterSeed []byte, transformedKey []by
 func decomposeContentBlocks31(r io.Reader) ([]byte, error) {
 	var contentData []byte
 	// Get all the content
-	content, err := ioutil.ReadAll(r)
+	content, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err
 	}

--- a/content.go
+++ b/content.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 )
 
 // Inner header bytes
@@ -110,7 +109,7 @@ ForLoop:
 			reader := bytes.NewReader(data)
 
 			binary.Read(reader, binary.LittleEndian, &protection) // Read memory protection flag
-			content, _ := ioutil.ReadAll(reader)                  // Read content
+			content, _ := io.ReadAll(reader)                      // Read content
 
 			ih.Binaries = append(
 				ih.Binaries,

--- a/credentials.go
+++ b/credentials.go
@@ -9,7 +9,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"reflect"
 	"regexp"
@@ -141,7 +141,7 @@ func ParseKeyFile(location string) ([]byte, error) {
 	}
 
 	var data []byte
-	if data, err = ioutil.ReadAll(file); err != nil {
+	if data, err = io.ReadAll(file); err != nil {
 		return nil, err
 	}
 

--- a/crypto.go
+++ b/crypto.go
@@ -12,6 +12,9 @@ const (
 	ARC4StreamID   uint32 = 1 // ID for ARC4 protection, not implemented
 	SalsaStreamID  uint32 = 2 // ID for Salsa20 protection
 	ChaChaStreamID uint32 = 3 // ID for ChaCha20 protection
+
+	ivChaCha20Length = 12
+	ivAESLength      = 16
 )
 
 // EncrypterManager is the manager to handle an Encrypter
@@ -41,11 +44,9 @@ func NewEncrypterManager(key []byte, iv []byte) (manager *EncrypterManager, err 
 	var encrypter Encrypter
 	manager = new(EncrypterManager)
 	switch len(iv) {
-	case 12:
-		// ChaCha20
+	case ivChaCha20Length:
 		encrypter, err = crypto.NewChaChaEncrypter(key, iv)
-	case 16:
-		// AES
+	case ivAESLength:
 		encrypter, err = crypto.NewAESEncrypter(key, iv)
 	default:
 		return nil, ErrUnsupportedEncrypterType

--- a/decoder.go
+++ b/decoder.go
@@ -6,7 +6,6 @@ import (
 	"encoding/xml"
 	"errors"
 	"io"
-	"io/ioutil"
 	"reflect"
 )
 
@@ -54,7 +53,7 @@ func (d *Decoder) Decode(db *Database) error {
 	}
 
 	// Decode raw content
-	rawContent, _ := ioutil.ReadAll(d.r)
+	rawContent, _ := io.ReadAll(d.r)
 	if err := decodeRawContent(db, rawContent, transformedKey); err != nil {
 		return err
 	}
@@ -89,7 +88,7 @@ func decodeRawContent(db *Database, content []byte, transformedKey []byte) (err 
 	} else {
 		// In Kdbx v3.1 you must decrypt before parse blocks
 		reader := bytes.NewReader(content)
-		content, err = ioutil.ReadAll(reader)
+		content, err = io.ReadAll(reader)
 		if err != nil {
 			return err
 		}
@@ -131,7 +130,7 @@ func decodeRawContent(db *Database, content []byte, transformedKey []byte) (err 
 		}
 		defer r.Close()
 
-		decryptedContent, _ = ioutil.ReadAll(r)
+		decryptedContent, _ = io.ReadAll(r)
 	}
 
 	db.Content.RawData = decryptedContent

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -1,7 +1,7 @@
 package gokeepasslib
 
 import (
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 )
@@ -35,7 +35,7 @@ func TestDecodeFile(t *testing.T) {
 			newCredentials: func() (*DBCredentials, error) {
 				file, err := os.Open("tests/kdbx3/example-key.key")
 				var keyData []byte
-				if keyData, err = ioutil.ReadAll(file); err != nil {
+				if keyData, err = io.ReadAll(file); err != nil {
 					return nil, nil
 				}
 
@@ -68,7 +68,7 @@ func TestDecodeFile(t *testing.T) {
 			newCredentials: func() (*DBCredentials, error) {
 				file, err := os.Open("tests/kdbx4/example-key.key")
 				var keyData []byte
-				if keyData, err = ioutil.ReadAll(file); err != nil {
+				if keyData, err = io.ReadAll(file); err != nil {
 					return nil, nil
 				}
 

--- a/header.go
+++ b/header.go
@@ -191,7 +191,7 @@ func NewKDBX4FileHeaders() *FileHeaders {
 			Rounds:      0,
 			Salt:        salt,
 			Parallelism: 2,
-			Memory:      1048576,
+			Memory:      1 * 1024 * 1024, // 1 MB
 			Iterations:  2,
 			Version:     19,
 		},

--- a/meta_data.go
+++ b/meta_data.go
@@ -4,6 +4,12 @@ import (
 	w "github.com/tobischo/gokeepasslib/v3/wrappers"
 )
 
+const (
+	_defaultHistoryMaxItems        = 10
+	_defaultHistorySize            = 6 * 1024 * 1024 // 6 MB
+	_defaultMaintenanceHistoryDays = 365             // 1 year
+)
+
 // MemProtection is a structure containing settings for MemoryProtection
 type MemProtection struct {
 	ProtectTitle    w.BoolWrapper `xml:"ProtectTitle"`
@@ -36,9 +42,9 @@ func NewMetaData(options ...MetaDataOption) *MetaData {
 		MasterKeyChanged:       &now,
 		MasterKeyChangeRec:     -1,
 		MasterKeyChangeForce:   -1,
-		HistoryMaxItems:        10,
-		HistoryMaxSize:         6291456, // 6 MB
-		MaintenanceHistoryDays: 365,
+		HistoryMaxItems:        _defaultHistoryMaxItems,
+		HistoryMaxSize:         _defaultHistorySize,
+		MaintenanceHistoryDays: _defaultMaintenanceHistoryDays,
 	}
 
 	for _, option := range options {

--- a/uuid.go
+++ b/uuid.go
@@ -6,11 +6,14 @@ import (
 	"errors"
 )
 
+// uuidLength defines how many bytes are in an uuid
+const uuidLength = 16
+
 // ErrInvalidUUIDLength is an error which is returned during unmarshaling if the UUID does not have 16 bytes length
 var ErrInvalidUUIDLength = errors.New("gokeepasslib: length of decoded UUID was not 16")
 
 // UUID stores a universal identifier for each group+entry
-type UUID [16]byte
+type UUID [uuidLength]byte
 
 // NewUUID returns a new randomly generated UUID
 func NewUUID() UUID {
@@ -48,9 +51,9 @@ func (u *UUID) UnmarshalText(text []byte) error {
 		*u = NewUUID()
 		return nil
 	}
-	if length != 16 {
+	if length != uuidLength {
 		return ErrInvalidUUIDLength
 	}
-	copy((*u)[:], id[:16])
+	copy((*u)[:], id[:uuidLength])
 	return nil
 }

--- a/wrappers/time.go
+++ b/wrappers/time.go
@@ -58,7 +58,7 @@ func Now(options ...TimeOption) TimeWrapper {
 // MarshalText marshals time into an RFC3339 compliant value in UTC (Kdbx v3.1)
 // On Kdbx v4 it calculates the timestamp subtracting seconds from the time date and encode it with base64
 func (tw TimeWrapper) MarshalText() ([]byte, error) {
-	t := time.Time(tw.Time).In(time.UTC)
+	t := tw.Time.In(time.UTC)
 	if y := t.Year(); y < 0 || y >= 10000 {
 		return nil, ErrYearOutsideOfRange
 	}


### PR DESCRIPTION
This PR aims to remove some magic numbers, extracting them to variables to improve readability.

`ioutil.ReadAll` is deprecated and has been replaces with `io.ReadAll`.

MegaBytes are expressed in `X * 1024 * 1024` format, to make the code more readable.

Redundant time cast has been removed from `wrappers/time.go`.