### PR TITLE
Fix data duplication in composeContentBlocks31

### DIFF
--- a/blocks.go
+++ b/blocks.go
@@ -191,16 +191,16 @@ func composeContentBlocks31(w io.Writer, contentData []byte) {
 	offset := 0
 	for offset < len(contentData) {
 		var hash [32]byte
-		var length uint32
-		var data []byte
+		var endOffset int
 
 		if len(contentData[offset:]) >= blockSplitRate {
-			data = append(data, contentData[offset:]...)
+			endOffset = offset + blockSplitRate
 		} else {
-			data = append(data, contentData...)
+			endOffset = len(contentData)
 		}
 
-		length = uint32(len(data))
+		data := contentData[offset:endOffset]
+		length := uint32(len(data))
 		hash = sha256.Sum256(data)
 
 		binary.Write(w, binary.LittleEndian, index)
@@ -208,7 +208,7 @@ func composeContentBlocks31(w io.Writer, contentData []byte) {
 		binary.Write(w, binary.LittleEndian, length)
 		binary.Write(w, binary.LittleEndian, data)
 		index++
-		offset += blockSplitRate
+		offset = endOffset
 	}
 	binary.Write(w, binary.LittleEndian, index)
 	binary.Write(w, binary.LittleEndian, [32]byte{})


### PR DESCRIPTION
## Summary

`composeContentBlocks31` has two slicing bugs that cause KDBX 3.1 files to silently inflate when re-encoded:

1. **Line 198** — the "large block" branch uses `contentData[offset:]` which appends *all* remaining data instead of a single `blockSplitRate` (1 MB) chunk.
2. **Line 200** — the "small block" branch uses `contentData` (from byte 0) instead of `contentData[offset:]` (from the current position).

Together these cause every block after the first to contain duplicate data, inflating the encoded file by ~2.5×. A 2.5 MB KDBX 3.1 database becomes ~6.4 MB after a round-trip decode/encode.

The KDBX 4 equivalent (`composeContentBlocks4`) already handles this correctly. This PR aligns the 3.1 path with the same pattern: compute `endOffset`, slice `[offset:endOffset]`, and advance `offset = endOffset`.

## Before (buggy)

```go
if len(contentData[offset:]) >= blockSplitRate {
    data = append(data, contentData[offset:]...)   // all remaining data
} else {
    data = append(data, contentData...)             // from start, not offset
}
// ...
offset += blockSplitRate
```

## After (fixed)

```go
if len(contentData[offset:]) >= blockSplitRate {
    endOffset = offset + blockSplitRate
} else {
    endOffset = len(contentData)
}
data := contentData[offset:endOffset]
// ...
offset = endOffset
```

## Testing

- All existing tests pass (`go test ./...`)
- Verified with a real 2.5 MB KDBX 3.1 database containing 386 entries, 338 history entries, and 83 binary attachments: re-encoded size went from 6.4 MB (2.59× original) to 2.58 MB (1.00× original)